### PR TITLE
update params.php

### DIFF
--- a/helpers/params.php
+++ b/helpers/params.php
@@ -37,10 +37,14 @@ if ($this->countModules('leftsidebar') && $this->countModules('rightsidebar'))
     $rightsidebar = "col-xs-12 col-sm-2";
     $componentarea = "col-xs-12 col-sm-8 col-sm-push-2";
 }
-elseif ($this->countModules('leftsidebar') or $this->countModules('rightsidebar'))
+elseif ($this->countModules('rightsidebar'))
+{
+    $rightsidebar = "col-xs-12 col-sm-3";
+    $componentarea = "col-xs-12 col-sm-9";
+}
+elseif ($this->countModules('leftsidebar'))
 {
     $leftsidebar = "col-xs-12 col-sm-3 col-sm-pull-9";
-    $rightsidebar = "col-xs-12 col-sm-3";
     $componentarea = "col-xs-12 col-sm-9 col-sm-push-3";
 }
 else


### PR DESCRIPTION
Als je alleen rightbar hebt wordt content toch 3 kolommen opgeschoven. Met de aangepaste code lijkt me logischer. Content blijft dan linkslijnend.

// Check Sidebar usage to automatic change the grid
if ($this->countModules('leftsidebar') && $this->countModules('rightsidebar'))
{
    $leftsidebar = "col-xs-12 col-sm-2 col-sm-pull-8";
    $rightsidebar = "col-xs-12 col-sm-2";
    $componentarea = "col-xs-12 col-sm-8 col-sm-push-2";
}
elseif ($this->countModules('rightsidebar'))
{
    $rightsidebar = "col-xs-12 col-sm-3";
    $componentarea = "col-xs-12 col-sm-9";
}
elseif ($this->countModules('leftsidebar'))
{
    $leftsidebar = "col-xs-12 col-sm-3 col-sm-pull-9";
    $componentarea = "col-xs-12 col-sm-9 col-sm-push-3";
}
else
{
    $componentarea = "col-sm-12";
}